### PR TITLE
Update 09_seo.md

### DIFF
--- a/src/docs/06_static-generators/metalsmith/09_seo.md
+++ b/src/docs/06_static-generators/metalsmith/09_seo.md
@@ -60,7 +60,7 @@ Meta tags are generated merging the values present in the record's *SEO meta tag
 
 ![foo](../../images/seo/global-seo.png)
 
-If the record doesn't have a *SEO meta tags* field, the method tries to guess reasonable values by inspecting the other fields of the record (single-line strings and images).
+If the record doesn't have a data in the *SEO meta tags* fields, the method tries to guess reasonable values by inspecting the other fields of the record (single-line strings and images).
 
 Your page title will be composed concatenating the title of the record together with the *Title suffix* setting. If the total length of the title exceeds 60 characters, the suffix will be omitted.
 

--- a/src/docs/06_static-generators/metalsmith/09_seo.md
+++ b/src/docs/06_static-generators/metalsmith/09_seo.md
@@ -60,7 +60,7 @@ Meta tags are generated merging the values present in the record's *SEO meta tag
 
 ![foo](../../images/seo/global-seo.png)
 
-If the record doesn't have a data in the *SEO meta tags* fields, the method tries to guess reasonable values by inspecting the other fields of the record (single-line strings and images).
+If the record doesn't have data in the *SEO meta tags* fields, the method tries to guess reasonable values by inspecting the other fields of the record (single-line strings and images).
 
 Your page title will be composed concatenating the title of the record together with the *Title suffix* setting. If the total length of the title exceeds 60 characters, the suffix will be omitted.
 


### PR DESCRIPTION
Documentation for the Managing SEO with the `seoMetaTags` method details:
> If the record doesn't have a SEO meta tags field, the method tries to guess reasonable values by inspecting the other fields of the record (single-line strings and images).

This is only the case, as far as I can tell, if there is still a `seo` content field present:
```
 get seoMetaTags() {
    const seoField = this.fields.find(f => f.fieldType === 'seo');

    if (seoField) {
      return seoTagsBuilder(this, this.entity.repo, i18n);
    }

    return null;
  }
```
https://github.com/datocms/js-datocms-client/blob/ba21a2516fe87408f7f164e935f545aea68a627e/src/local/Item.js#L117